### PR TITLE
Fixed VS2013 32bit

### DIFF
--- a/src/server/scripts/Pandaria/Raids/SiegeOfOrgrimmar/instance_siege_of_orgrimmar.cpp
+++ b/src/server/scripts/Pandaria/Raids/SiegeOfOrgrimmar/instance_siege_of_orgrimmar.cpp
@@ -212,7 +212,7 @@ class instance_SiegeOfOrgrimmar : public InstanceMapScript
                 }*/
             }
             
-            uint64 GetData64(uint32 type)
+            uint64 GetData64(uint32 type) const
             {
                 switch (type)
                 {


### PR DESCRIPTION
I compile in both 64bit and 32bit in windows 10 VS2013

came accross this compile error in 32bit

2>  instance_siege_of_orgrimmar.cpp
2>C:\Users\wowharley\Desktop\JadeCore548\src\server\scripts\Pandaria\Raids\SiegeOfOrgrimmar\instance_siege_of_orgrimmar.cpp(216): error C4263: 'uint64 instance_SiegeOfOrgrimmar::instance_SiegeOfOrgrimmar_InstanceMapScript::GetData64(uint32)' : member function does not override any base class virtual member function
2>C:\Users\wowharley\Desktop\JadeCore548\src\server\scripts\Pandaria\Raids\SiegeOfOrgrimmar\instance_siege_of_orgrimmar.cpp(296): error C4264: 'uint64 ZoneScript::GetData64(uint32) const' : no override available for virtual member function from base 'ZoneScript'; function is hidden
2>          C:\Users\wowharley\Desktop\JadeCore548\src\server\game\Maps\ZoneScript.h(45) : see declaration of 'ZoneScript::GetData64'
2>          C:\Users\wowharley\Desktop\JadeCore548\src\server\game\Maps\ZoneScript.h(28) : see declaration of 'ZoneScript'

PR fixed the 32bit compile, modifying 

uint64 GetData64(uint32 type) 
to
uint64 GetData64(uint32 type) const