### PR TITLE
Core/Entities Player: Remove code

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -1679,19 +1679,6 @@ void Player::Update(uint32 p_time)
         m_spellModTakingSpell = NULL;
     }
 
-    if ((GetMap()->IsRaid()) && (GetGroup() == NULL) && (GetSession()->GetSecurity() < 1))
-    {
-        TeleportTo(530,-1890.4f,5398.62f,-12.42f,4.04241f);
-    }
-
-    if ((GetMap()->IsRaid()) && (GetGroup() != NULL) && GetMap()->Is25ManRaid() && (GetGroup()->GetMembersCount() > 25))
-    {
-        TeleportTo(530,-1890.4f,5398.62f,-12.42f,4.04241f);
-    }
-    if ((GetMap()->IsRaid()) && (GetGroup() != NULL) && !GetMap()->Is25ManRaid()  && (GetGroup()->GetMembersCount() > 10))
-    {
-        TeleportTo(530,-1890.4f,5398.62f,-12.42f,4.04241f);
-    }
 
     //used to implement delayed far teleports
     SetCanDelayTeleport(true);


### PR DESCRIPTION
This code is useless and breaks config function to ignore raid group.